### PR TITLE
Update ingress to networking.k8s.io/v1, supporting k8s 1.22+

### DIFF
--- a/predator/templates/ingress.yaml
+++ b/predator/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "predator.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,9 +32,12 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $servicePort }}
+        - backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                number: {{ $servicePort }}
+          path: {{ $ingressPath }}
+          pathType: ImplementationSpecific
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Kubernetes 1.22+ does not support `extensions/v1beta1`, this PR upgrades ingress template to the new `networking.k8s.io/v1` API.