### PR TITLE
Add max_upload_file_size_mb var to config map

### DIFF
--- a/predator/templates/configmap.yaml
+++ b/predator/templates/configmap.yaml
@@ -39,6 +39,9 @@ data:
 {{ if .Values.streaming.excludedAttributes }}
   STREAMING_EXCLUDED_ATTRIBUTES: {{ .Values.streaming.excludedAttributes }}
 {{ end }}
+{{ if .Values.maxUploadFileSizeMB }}
+  MAX_UPLOAD_FILE_SIZE_MB: {{ .Values.maxUploadFileSizeMB | quote }}
+{{ end }}
 {{ if .Values.streaming.kafka.brokers }}
   KAFKA_BROKERS: {{ .Values.streaming.kafka.brokers }}
   KAFKA_CLIENT_ID: {{ .Values.streaming.kafka.clientId }}

--- a/predator/templates/configmap.yaml
+++ b/predator/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
   STREAMING_PLATFORM_HEALTH_CHECK_TIMEOUT_MS: {{ .Values.streaming.platformHealthCheckTimeoutMs | quote }}
 {{ end }}
 {{ if .Values.streaming.excludedAttributes }}
-STREAMING_EXCLUDED_ATTRIBUTES: {{ .Values.streaming.excludedAttributes }}
+  STREAMING_EXCLUDED_ATTRIBUTES: {{ .Values.streaming.excludedAttributes }}
 {{ end }}
 {{ if .Values.streaming.kafka.brokers }}
   KAFKA_BROKERS: {{ .Values.streaming.kafka.brokers }}

--- a/predator/values.yaml
+++ b/predator/values.yaml
@@ -68,7 +68,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-
+maxUploadFileSizeMB: 10
 
 streaming:
   platform:


### PR DESCRIPTION
- Add `maxUploadFileSizeMB` variable to configmap
    It is already supported in the code, just wasn't exposed before.
    See https://github.com/Zooz/predator/pull/595 and
        https://github.com/Zooz/predator/issues/593 for details.
- Fix bad indentation for STREAMING_EXCLUDED_ATTRIBUTES key
